### PR TITLE
[CONFIG] Changed Mongo version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       MONGODB_CONECTION_URL: mongodb://root:example@mongo:27017/
     restart: always
   mongo:
-    image: mongo:5.0.2
+    image: mongo:4.4
     restart: always
     ports:
       - 27017:27017


### PR DESCRIPTION
Mongo container was unable to run because it required a CPU with AVX support, which my Ubuntu VM doesn't seem to have. 

The solution was to use an older version of MongoDB that doesn't require AVX support. 