### PR TITLE
Changed Mongo version to 4.4

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       MONGODB_CONECTION_URL: mongodb://root:example@mongo:27017/
     restart: always
   mongo:
-    image: mongo:5.0.2
+    image: mongo:4.4
     restart: always
     ports:
       - 27017:27017


### PR DESCRIPTION
MongoDB container was unable to run on my Ubuntu VM because it requires a CPU with AVX support. 

The solution was to use an older version that doesn't have AVX support. 