### PR TITLE
[API] Updated deletion for non-existing ID

### DIFF
--- a/src/main/java/ro/unibuc/hello/service/SingerService.java
+++ b/src/main/java/ro/unibuc/hello/service/SingerService.java
@@ -2,6 +2,7 @@ package ro.unibuc.hello.service;
 
 import org.bson.types.ObjectId;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.stereotype.Component;
 import ro.unibuc.hello.data.SingerEntity;
 import ro.unibuc.hello.data.SingerRepository;
@@ -59,8 +60,11 @@ public class SingerService {
     }
 
     public String deleteSinger(String id) {
-        singerRepository.deleteById(String.valueOf(new ObjectId(id)));
-        return "Singer " + id + " has been successfully deleted.";
-
+        try {
+            singerRepository.deleteById(String.valueOf(new ObjectId(id)));
+        } catch (EmptyResultDataAccessException e) {
+            return "Error: The singer with the ID " + id + " does not exist.";
+        }
+        return "Delete successful";
     }
 }

--- a/src/test/java/ro/unibuc/hello/controller/SingerControllerTest.java
+++ b/src/test/java/ro/unibuc/hello/controller/SingerControllerTest.java
@@ -21,6 +21,7 @@ import java.util.List;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 
@@ -143,19 +144,23 @@ For example:
         SingerDTO singer = new SingerDTO("Alex Velea", 38, "Urban", 70, new String[]{"Yamasha"});
         String id = "1";
         singer.setId(id);
-        String expectedResponse = "Singer with id " + id + " has been deleted.";
+        String expectedResponse = "Delete successful";
+        String errorResponse = "Error: The singer with the ID " + id + " does not exist.";
 
         when(singerService.deleteSinger(id)).thenReturn(expectedResponse);
+        when(singerService.deleteSinger("nonexistent_id")).thenReturn(errorResponse);
 
-        // Act
-        MvcResult result = mockMvc.perform(delete("/singer/delete")
+        // Act and Assert for successful deletion
+        mockMvc.perform(delete("/singer/delete")
                         .param("id", id))
                 .andExpect(status().isOk())
-                .andReturn();
+                .andExpect(content().string(expectedResponse));
 
-        // Assert
-        Assertions.assertEquals(result.getResponse().getContentAsString(), expectedResponse);
-
+        // Act and Assert for error case
+        mockMvc.perform(delete("/singer/delete")
+                        .param("id", "nonexistent_id"))
+                .andExpect(status().isOk())
+                .andExpect(content().string(errorResponse));
     }
 
 }


### PR DESCRIPTION
Updated SingerDelete and SingerControllerTest (the test_deleteSinger() method) to handle the case when we try to delete a singer with an ID that doesn't exist.

